### PR TITLE
feat: initate sampling based on info bins configs

### DIFF
--- a/kits.json
+++ b/kits.json
@@ -29,6 +29,11 @@
       "id": "extract-gender",
       "description": "Extract Patient.gender value sampled instances",
       "mapping": "doExtractGender"
+    },
+    {
+      "id": "sample-wrapper",
+      "description": "Initiate the sampling process",
+      "mapping": "doSampleWrapper"
     }
   ],
   "kits": [
@@ -98,6 +103,7 @@
                   "description": "Patient Identifier system distribution",
                   "details": "Check if the distribution of Patient.identifier.system makes sense.",
                   "actions": [
+                    "sample-wrapper",
                     "extract-identifiers"
                   ]
                 },
@@ -107,6 +113,7 @@
                   "description": "Patient gender value distribution",
                   "details": "Check if the distribution of Patient.identifier.system makes sense.",
                   "actions": [
+                    "sample-wrapper",
                     "extract-gender"
                   ]
                 }

--- a/maps/doInfoBinsDistinct.txt
+++ b/maps/doInfoBinsDistinct.txt
@@ -1,0 +1,155 @@
+// doInfoBinsDistinct - Create 1 obejct per resourceType to be sampled with the Max(historicalDepthYears) Max(amountToCollect) and arbitrary searchParam & elementName (assuming a resourceType is always sampled based on the saem combinaiton of the both)
+
+// See below unfinished code
+(
+  $infoBinsDistinct := [
+    {
+      "resourceType": "CarePlan",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 1,
+      "searchParam": "date",
+      "elementName": "period"
+    },
+    {
+      "resourceType": "Comnmunication",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "sent",
+      "elementName": "sent"
+    },
+    {
+      "resourceType": "Condition",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 1,
+      "searchParam": "recorded-date",
+      "elementName": "recordedDate"
+    },
+    {
+      "resourceType": "DiagnosticReport",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "date",
+      "elementName": "effective"
+    },
+    {
+      "resourceType": "DocumentReference",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "date",
+      "elementName": "date"
+    },
+    {
+      "resourceType": "Encounter",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "date",
+      "elementName": "period"
+    },
+    {
+      "resourceType": "Goal",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 1,
+      "searchParam": "start-date",
+      "elementName": "startDate"
+    },
+    {
+      "resourceType": "ImagingStudy",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "started",
+      "elementName": "started"
+    },
+    {
+      "resourceType": "MedicationAdministration",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "effective-time",
+      "elementName": "effective[x]"
+    },
+    {
+      "resourceType": "MedicationDispense",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "whenhandedover",
+      "elementName": "whenHandedOver"
+    },
+    {
+      "resourceType": "MedicationRequest",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "authoredon",
+      "elementName": "authoredOn"
+    },
+    {
+      "resourceType": "Observation",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 1,
+      "searchParam": "date",
+      "elementName": "effective"
+    },
+    {
+      "resourceType": "ObservationLab",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "date",
+      "elementName": "effective"
+    },
+    {
+      "resourceType": "Patient",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 200,
+      "searchParam": "birthdate",
+      "elementName": "birthDate"
+    },
+    {
+      "resourceType": "Procedure",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "date",
+      "elementName": "performed"
+    },
+    {
+      "resourceType": "QuestionaireResponse",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 1,
+      "searchParam": "authored",
+      "elementName": "authored"
+    },
+    {
+      "resourceType": "ResearchSubject",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "date",
+      "elementName": "period"
+    },
+    {
+      "resourceType": "ServiceRequest",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "authored",
+      "elementName": "authoredOn"
+    },
+    {
+      "resourceType": "Specimen",
+      "amountToCollect": 1000,
+      "historicalDepthYears": 5,
+      "searchParam": "collected",
+      "elementName": "collected"
+    }
+  ]
+
+  ;$writeFile($infoBinsDistinct,'infoBinsDistinct.json')
+
+// This is unfinished code replaced by mnualy created file above
+  // $ILInformationBins := $readFile('$ILInformationBins.json')
+
+  // ;$distinctResourceTypes := $ILInformationBins.resourceTypes.resourceType~>$distinct()
+
+  // ;$distinctResourceTypes@$drt.{
+  //   'resourceType':$drt
+  //   ,'amountToCollect' : $ILInformationBins.resourceTypes[resourceType=$drt].amountToCollect~>$max()
+  //   ,"historicalDepthYears": $ILInformationBins.resourceTypes[resourceType=$drt].historicalDepthYears~>$max()
+  //   ,"searchParam": $ILInformationBins.resourceTypes[resourceType=$drt].searchParam[0]
+  //   ,"elementName": $ILInformationBins.resourceTypes[resourceType=$drt].elementName[0]
+  //    }
+)

--- a/maps/doSampleResources.txt
+++ b/maps/doSampleResources.txt
@@ -1,12 +1,11 @@
-// ?
-/*Sample resources based on params & write each to file*/
+/*doSampleWrapper - Sample resources based on params & write each to file*/
 
 (
   $warning({'=========> Map start <=========' : $now()});
   
   /* get the base url of the fhir server by making a dummy search */
   $baseUrl := $fhirServer;
-  /* set the m  ximum number of failed search attempts */
+  /* set the maximum number of failed search attempts */
   $maxFailedAttempts := 5;
   /* set delay seed size that is equivalent to approx. one second */
   $seedPerSecond := 600000;
@@ -216,84 +215,12 @@
    $instancesListResources.$writeFile($,'['& $.resourceType &']_['& $.id &'].json');
 
 /*Example input (derived from the above example)*/
-    /*{*/
-/*      "resourceType": "Patient",*/
-      /*"amountToCollect": 1000,*/
-      /*"minDate": "1900-01-01",*/
-      /*"maxDate": "2020-01-01",*/
-      /*"searchParam": "birthdate",*/
-      /*"elementName": "birthDate"*/
-    /*}*/
-
-    /*{*/
-/*      "resourceType": "Encounter",*/
-      /*"amountToCollect": 500,*/
-      /*"minDate": "2024-01-01",*/
-      /*"maxDate": "2024-03-01",*/
-      /*"searchParam": "date",*/
-      /*"elementName": "period"*/
-    /*}*/
-
-/*    {*/
-/*      "resourceType": "Practitioner",*/
-      /*"amountToCollect": 1000,*/
-      /*"minDate": "1900-01-01",*/
-      /*"maxDate": "2020-01-01",*/
-      /*"searchParam": "_lastUpdated",*/
-      /*"elementName": "lastUpdated"*/
-    /*}*/
-
-/*    {*/
-/*      "resourceType": "PractitionerRole",*/
-      /*"amountToCollect": 1000,*/
-      /*"minDate": "1900-01-01",*/
-      /*"maxDate": "2020-01-01",*/
-      /*"searchParam": "_lastUpdated",*/
-      /*"elementName": "lastUpdated"*/
-    /*}*/
-
-/*    {*/
-      /*"resourceType": "Observation",*/
-      /*"amountToCollect": 5000,*/
-      /*"minDate": "2024-01-01",*/
-      /*"maxDate": "2024-03-01",*/
-      /*"searchParam": "date",*/
-      /*"elementName": "effectiveDateTime"*/
-    /*}*/
-
-/*    {*/
-      /*"resourceType": "Organization",*/
-      /*"amountToCollect": 5000,*/
-      /*"minDate": "2024-01-01",*/
-      /*"maxDate": "2024-03-01",*/
-      /*"searchParam": "?",*/
-      /*"elementName": "?"*/
-    /*}*/
-
-/*    {*/
-      /*"resourceType": "Location",*/
-      /*"amountToCollect": 5000,*/
-      /*"minDate": "2024-01-01",*/
-      /*"maxDate": "2024-03-01",*/
-      /*"searchParam": "?",*/
-      /*"elementName": "?"*/
-    /*}*/
-
-/*    {*/
-      /*"resourceType": "Organization",*/
-      /*"amountToCollect": 5000,*/
-      /*"minDate": "2024-01-01",*/
-      /*"maxDate": "2024-03-01",*/
-      /*"searchParam": "?",*/
-      /*"elementName": "?"*/
-    /*}*/
-
-/*    {*/
-      /*"resourceType": "Organization",*/
-      /*"amountToCollect": 5000,*/
-      /*"minDate": "2024-01-01",*/
-      /*"maxDate": "2024-03-01",*/
-      /*"searchParam": "?",*/
-      /*"elementName": "?"*/
-    /*}*/
+/*{*/
+  /*"resourceType": "Patient",*/
+  /*"amountToCollect": 1000,*/
+  /*"minDate": "1900-01-01",*/
+  /*"maxDate": "2020-01-01",*/
+  /*"searchParam": "birthdate",*/
+  /*"elementName": "birthDate"*/
+/*}*/
 )

--- a/maps/doSampleWrapper.txt
+++ b/maps/doSampleWrapper.txt
@@ -1,0 +1,8 @@
+// doSampleWrapper - execute building an input file & smpling
+(
+  // Create a flattened sampeling input file
+  $doSamplingInput()
+
+  // For each input, perform a sample
+  ;$readFile('samplingInput.json').$doSampleResources($)
+)

--- a/maps/doSamplingInput.txt
+++ b/maps/doSamplingInput.txt
@@ -1,6 +1,10 @@
-// doSamplingInput - Create input for sampling
+// doSamplingInput - Create input for sampling, one object for each resourceType (done on infoBinsDistinct.json), with the maximal historical depth
 (
-  $samplingInput := $readFile('$ILInformationBins.json').resourceTypes.{
+  // Create a distinct list of resourceTypes to be sampled
+  $doInfoBinsDistinct()
+  
+  // Create sampling map input
+  ;$samplingInput := $readFile('infoBinsDistinct.json').{
     'resourceType' : resourceType
     ,"amountToCollect" : $sampleSize
     ,"minDate" : $fromMillis($toMillis($now())-historicalDepthYears*365*24*60*60*1000) /*Sample historical data as defined*/


### PR DESCRIPTION
Automate sampling run.

Sampling input is based on info bins requirements such as relevant resource types, historical depth etc.

The sampling process is provided with a single input object for each resource type:
* sampling size - The max provided in the source file (later to be edited user).
This is overridden by the environment parm RESOURCE_SAMPLE_SIZE if one is defined in the .env file.
* historical depth - The max defined in info bins for said resourceType + 1 month into the future.
* search param - as defined in info bins  