### PR TITLE
v1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "il-fhir-certificator",
-  "version": "1.17.2",
+  "version": "1.18.0",
   "description": "FHIR Certificator for Israeli MoH",
   "scripts": {
     "clean": "rimraf dist && rimraf ui\\dist && rimraf report\\dist",

--- a/src/helpers/extraBindings/index.ts
+++ b/src/helpers/extraBindings/index.ts
@@ -5,5 +5,6 @@ import { toMarkdown } from './markdown';
 import { validate } from './validate';
 
 const instant = () => Date.now();
+const setStatus = () => {}; // noop for dev mode. overridden with actual func when invoked as an action
 
-export const extraBindings = { instant, validate, http, writeFile, readFile, makeDir, readDir, resolveCanonical, readPackageIndex, toMarkdown };
+export const extraBindings = { setStatus, instant, validate, http, writeFile, readFile, makeDir, readDir, resolveCanonical, readPackageIndex, toMarkdown };


### PR DESCRIPTION
Action status reporting improvements:
* status of action is set to `in-progress` as the engine starts execution
* $setStatus function for writing customized statuses without hard-coding the mapping id
* no-op $setStatus function so anonymous executions of expressions in development mode will not fail