### PR TITLE
Refactor status reporting

### DIFF
--- a/kits.json
+++ b/kits.json
@@ -130,40 +130,36 @@
       "description": "(Test 59) - Encounter.class distribution",
       "mapping": "doExtractEncounterClass"
     },
-	{
+    {
       "id": "isSuccessfulSearchBundleType",
       "description": "(Test 109) - Validate search result is Bundle with type=searchset",
       "mapping": "isSuccessfulSearchBundleType"
     },
-	{
-	  "id": "isGetHttp200",
+    {
+      "id": "isGetHttp200",
       "description": "(Test 90) - Validate that the returned HTTP status is 200(OK)",
-      "mapping": "isGetHttp200"	
-	},
-	{
+      "mapping": "isGetHttp200"
+    },
+    {
       "id": "doExtractEncounterType",
       "description": "(Test 64) - Encounter.type distribution",
       "mapping": "doExtractEncounterType"
     },
-	{
+    {
       "id": "doExtractConditionRecordedDate",
       "description": "(Test 174) - Condition.recordedDate distribution",
       "mapping": "doExtractConditionRecordedDate"
     },
-	{
+    {
       "id": "doExtractPractitionerIdentifier",
       "description": "(Test 58) - Practitioner.identifier distribution",
       "mapping": "doExtractPractitionerIdentifier"
     },
-	{
+    {
       "id": "doExtractConditionCode",
       "description": "(Test 178) - Condition.code.coding.system distribution",
       "mapping": "doExtractConditionCode"
     }
-	
-	
-	
-
   ],
   "kits": [
     {
@@ -272,7 +268,7 @@
                     "doExtractEncounterClass"
                   ]
                 },
-				{
+                {
                   "id": "test64",
                   "name": "Encounter type distribution",
                   "description": "Encounter type distribution",
@@ -284,12 +280,11 @@
                 }
               ]
             },
-			{
+            {
               "id": "condition-dist",
               "name": "Condition elements distributions",
               "children": [
-                
-				{
+                {
                   "id": "test174",
                   "name": "Condition recorded date distribution",
                   "description": "Condition recorded date distribution",
@@ -299,7 +294,7 @@
                     "doExtractConditionRecordedDate"
                   ]
                 },
-				{
+                {
                   "id": "test178",
                   "name": "Condition code distribution",
                   "description": "Condition code distribution",
@@ -311,7 +306,7 @@
                 }
               ]
             },
-			{
+            {
               "id": "practitioner-dist",
               "name": "Practitioner elements distribution",
               "children": [
@@ -412,9 +407,9 @@
                   "description": "Test FHIR endpoint pages results with required links via forced paging done by asking for a single resource on each page of a search set.",
                   "details": "The result collection can be long, so servers may use paging. If they do, they SHALL use the method described below (adapted from RFC 5005 (Feed Paging and Archiving ) for breaking the collection into pages if appropriate.\n3.1.0.9 search \nhttps://www.hl7.org/fhir/r4/http.html#search\nPaged feed documents MUST have at least one of these link relations present\n3.  Paged Feeds\nhttps://datatracker.ietf.org/doc/html/rfc5005#section-3\n\n3.1.0.14 Paging \n,https://www.hl7.org/fhir/r4/http.html#paging",
                   "actions": [
-                    "doInfoBinsDistinct"
-                    ,"doCountResources"
-                    ,"isPagingSearch"
+                    "doInfoBinsDistinct",
+                    "doCountResources",
+                    "isPagingSearch"
                   ]
                 }
               ]
@@ -432,21 +427,21 @@
                     "sample-wrapper",
                     "doSuccessfulSearch",
                     "isSuccessfulSearchBundle"
-                             ]
+                  ]
                 },
-		{
+                {
                   "id": "test109",
                   "name": "Validate search interaction returns Bundle of type searchset",
                   "description": "The return content SHALL be a Bundle with type = searchset",
                   "details": "The return content SHALL be a Bundle with type = searchset",
                   "actions": [
-				       "sample-wrapper",
-				       "doSuccessfulSearch",
-					   "isSuccessfulSearchBundleType"
-                          ]
-                 }
+                    "sample-wrapper",
+                    "doSuccessfulSearch",
+                    "isSuccessfulSearchBundleType"
+                  ]
+                }
               ]
-            }  
+            }
           ]
         },
         {
@@ -503,27 +498,26 @@
                 },
                 {
                   "id": "test29",
-                  "name": "Cehck ID element exist",
+                  "name": "Check ID element exists",
                   "description": "Check the returned resource SHALL have an id element",
                   "details": "Check the returned resource SHALL have an id element",
                   "actions": [
                     "sample-wrapper",
                     "doSuccessfulReadResponse",
                     "isReadHasId"
-                       ]
+                  ]
                 },
-		{
+                {
                   "id": "test90",
                   "name": "HTTP status is 200",
                   "description": "Confirm that the returned HTTP status is 200(OK)",
                   "details": "Confirm that the returned HTTP status is 200(OK)",
                   "actions": [
-				    "sample-wrapper",
-                    "doSuccessfulReadResponse", 
+                    "sample-wrapper",
+                    "doSuccessfulReadResponse",
                     "isGetHttp200"
-                             ]
-                } 
-		
+                  ]
+                }
               ]
             }
           ]

--- a/maps/doBirthDateDist.txt
+++ b/maps/doBirthDateDist.txt
@@ -1,13 +1,8 @@
 // doBirthDateDist (Test 68) - Patient.birthDate distribution
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doBirthDateDist.json')
 
   // List all sampled Patient instances (only) file names
-    ;$sampledResources := $readDir()[$startsWith($, '[Patient]_[') and $endsWith($,'].json')]
+    $sampledResources := $readDir()[$startsWith($, '[Patient]_[') and $endsWith($,'].json')]
 
   // For each sampled resource create an object with relevant data (file name, resource id etc) including if the id is or is not valid
     ;$birthDates := $sampledResources@$fn.$readFile($fn).{

--- a/maps/doCountResources.txt
+++ b/maps/doCountResources.txt
@@ -2,11 +2,6 @@
 // doInfoBinsDistinct
 
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doCountResources.json')
   
   /*Extract data*/
       ;$baseUrl := $search('Patient').entry[0].fullUrl.$substringBefore($,'Patient')

--- a/maps/doCountResources.txt
+++ b/maps/doCountResources.txt
@@ -4,7 +4,7 @@
 (
   
   /*Extract data*/
-      ;$baseUrl := $search('Patient').entry[0].fullUrl.$substringBefore($,'Patient')
+      $baseUrl := $search('Patient').entry[0].fullUrl.$substringBefore($,'Patient')
 
       ;$resourceCount := $readFile('infoBinsDistinct.json').resourceType@$rt.$http({
         'baseUrl': $baseUrl,

--- a/maps/doExtractConditionCode.txt
+++ b/maps/doExtractConditionCode.txt
@@ -1,13 +1,7 @@
 // doExtractConditionCode (Test 178) - extract Condition.code from sampled instances and write to flat file
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doExtractConditionCode.json')
-
   /*List all sampled resources file names*/
-    ;$sampledResourcesNames := $readDir()[$contains(/\[Condition\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
+    $sampledResourcesNames := $readDir()[$contains(/\[Condition\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
     // ;$count($sampledResourcesNames)
 
   /*Extract relevant elements from all sampled resources and flatten*/
@@ -20,10 +14,4 @@
 
   // /*Write flatten  results to folder*/
     ;$writeFile($code,'conditionCodeDistribution.json')
-
-  /*Write completed msg*/
-    ;{
-      'statusCode':'completed'
-      ,'statusText':'Completed'
-    } ~> $writeFile('actionStatus_doExtractConditionCode.json')
 )

--- a/maps/doExtractConditionRecordedDate.txt
+++ b/maps/doExtractConditionRecordedDate.txt
@@ -52,9 +52,4 @@
   // /*Write flatten results to folder*/
     $writeFile($arrayCntStartOfTheWeek,'conditionRecordedDateDistribution.json')
 
-  /*Write completed msg*/
-    {
-      'statusCode':'completed'
-      ,'statusText':'Completed'
-    } ~> $writeFile('actionStatus_doExtractConditionRecordedDate.json')
 )

--- a/maps/doExtractConditionRecordedDate.txt
+++ b/maps/doExtractConditionRecordedDate.txt
@@ -1,11 +1,5 @@
 // doExtractConditionRecordedDate (Test 174) - extract Condition.recordedDate from sampled instances and write to a flat file
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doExtractConditionRecordedDate.json');
-
    // Given a recordedDate parameter, this function returns its day of the week number, 
    // where Sunday is 1, Monday is 2, and so on
    $getDayOfWeekSundayStart := function($recordedDate)

--- a/maps/doExtractEncounterClass.txt
+++ b/maps/doExtractEncounterClass.txt
@@ -1,13 +1,8 @@
 // doExtractEncounterClass (Test 59) - extract Encounter.class from sampeled instances and write to flat file
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doExtractEncounterClass.json')
 
   /*List all sampled resources file names*/
-    ;$sampledResourcesNames := $readDir()[$contains(/\[Encounter\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
+    $sampledResourcesNames := $readDir()[$contains(/\[Encounter\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
     // ;$count($sampledResourcesNames)
 
   /*Extract relevant elements from all sampled resources and flatten*/

--- a/maps/doExtractEncounterClass.txt
+++ b/maps/doExtractEncounterClass.txt
@@ -15,10 +15,4 @@
 
   // /*Write flatten results to folder*/
     ;$writeFile($gender,'encounterClassDistribution.json')
-
-  /*Write completed msg*/
-    ;{
-      'statusCode':'completed'
-      ,'statusText':'Completed'
-    } ~> $writeFile('actionStatus_doExtractEncounterClass.json')
 )

--- a/maps/doExtractEncounterType.txt
+++ b/maps/doExtractEncounterType.txt
@@ -1,13 +1,7 @@
 // doExtractEncounterType (Test 64) - extract Encounter.type from sampeled instances and write to flat file
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doExtractEncounterType.json')
-
   /*List all sampled resources file names*/
-    ;$sampledResourcesNames := $readDir()[$contains(/\[Encounter\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
+    $sampledResourcesNames := $readDir()[$contains(/\[Encounter\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
 
 
   /*Extract relevant elements from all sampled resources and flatten*/

--- a/maps/doExtractEncounterType.txt
+++ b/maps/doExtractEncounterType.txt
@@ -15,10 +15,4 @@
 
   // /*Write flatten results to folder*/
     ;$writeFile($type,'encounterTypeDistribution.json')
-
-  /*Write completed msg*/
-    ;{
-      'statusCode':'completed'
-      ,'statusText':'Completed'
-    } ~> $writeFile('actionStatus_doExtractEncounterType.json')
 )

--- a/maps/doExtractGender.txt
+++ b/maps/doExtractGender.txt
@@ -15,10 +15,4 @@
 
   // /*Write flatten results to folder*/
     ;$writeFile($gender,'distributionGender.json')
-
-  /*Write completed msg*/
-    ;{
-      'statusCode':'completed'
-      ,'statusText':'Completed'
-    } ~> $writeFile('actionStatus_doExtractGender.json')
 )

--- a/maps/doExtractGender.txt
+++ b/maps/doExtractGender.txt
@@ -1,14 +1,8 @@
 // ?
 // doExtractGender - extract Geneder from sampeled Patient instances and write to flat file
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doExtractGender.json')
-
   /*List all sampled resources file names*/
-    ;$sampledResourcesNames := $readDir()[$contains(/\[Patient\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
+    $sampledResourcesNames := $readDir()[$contains(/\[Patient\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
     // ;$count($sampledResourcesNames)
 
   /*Extract relevant elements from all sampled resources and flatten*/

--- a/maps/doExtractIdentifiers.txt
+++ b/maps/doExtractIdentifiers.txt
@@ -1,14 +1,8 @@
 /*doExtractIdentifiers - extract resource identifiers from all sampled instances*/
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doExtractIdentifiers.json')
-
   /*Extract identifiers*/
     /*List all sampled resources file names*/
-      ;$sampledResources := $readDir()[$contains($,/\[.*\]_\[.*\].json/i)]
+      $sampledResources := $readDir()[$contains($,/\[.*\]_\[.*\].json/i)]
     
     /*For each sampled resource, extract and faltten the identifer and write to disk*/
       ;$identifiers := $sampledResources.$readFile($).identifier.system.{

--- a/maps/doExtractIds.txt
+++ b/maps/doExtractIds.txt
@@ -1,13 +1,7 @@
 // doExtractIds (Test31) - Check if all sampled instances resource.id comply with FHIR id datatype requirements
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doExtractIds.json')
-
   // List all sampled resources (only, exclude other files found in IO folder) file names
-    ;$sampledResources := $readDir()[$contains(/\[[A-Za-z]+\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]
+    $sampledResources := $readDir()[$contains(/\[[A-Za-z]+\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]
 
   // For each sampled resource create an object with relevant data (file name, resource id etc) including if the id is or is not valid
     ;$sampledResourcesIds := $sampledResources@$fn.$readFile($fn).{

--- a/maps/doExtractPractitionerIdentifier.txt
+++ b/maps/doExtractPractitionerIdentifier.txt
@@ -1,13 +1,7 @@
 // doExtractPractitionerIdentifier (Test 58) - extract Practitioner.Identifier from sampled instances and write to flat file
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doExtractPractitionerIdentifier.json')
-
-  /*List all sampled resources file names*/
-    ;$sampledResourcesNames := $readDir()[$contains(/\[Practitioner\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
+ /*List all sampled resources file names*/
+    $sampledResourcesNames := $readDir()[$contains(/\[Practitioner\]_\[[A-Za-z0-9\-\.]{1,64}\]\.json/)]^($)
     // ;$count($sampledResourcesNames)
 
   /*Extract relevant elements from all sampled resources and flatten*/
@@ -22,10 +16,4 @@
 
   // /*Write flatten !!!distinct!!! results to folder*/
     ;$writeFile($distinct($identifier),'practitionerIdentifierDistribution.json')
-
-  /*Write completed msg*/
-    ;{
-      'statusCode':'completed'
-      ,'statusText':'Completed'
-    } ~> $writeFile('actionStatus_doExtractPractitionerIdentifier.json')
 )

--- a/maps/doGetMetadata.txt
+++ b/maps/doGetMetadata.txt
@@ -1,13 +1,7 @@
 /*doGetMetadata - This map trys to fetch the provided server CapabilityStatement and saves it to file for later steps*/
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doGetMetadata.json')
-  
   /*Fetch base url*/
-    ;$baseUrl := $fhirServer
+    $baseUrl := $fhirServer
 
   /*Get metadata and write it to file*/
     ;$readResponse := $http({

--- a/maps/doSampleWrapper.txt
+++ b/maps/doSampleWrapper.txt
@@ -1,12 +1,6 @@
 (
   // doSampleWrapper - execute building an input file & sampling
 
-  /*Write initial map status for UI to status file*/
-  {
-    'statusCode':'in-progress'
-    ,'statusText':'in-progress'
-  } ~> $writeFile('actionStatus_doSampleWrapper.json');
-
   // Create a flattened sampeling input file
   $doSamplingInput();
 

--- a/maps/doSuccessfulSearch.txt
+++ b/maps/doSuccessfulSearch.txt
@@ -17,8 +17,5 @@
     ~> $writeFile('SuccessfulSearchResponse.json');
 
   /*Write final map status for UI to status file*/
-    {
-    'statusCode':'passed',
-    'statusText':'passed'
-    } ~> $writeFile('actionStatus_doSuccessfulSearch.json')
+    $setStatus('passed', 'Passed')
 )	

--- a/maps/doSuccessfulSearch.txt
+++ b/maps/doSuccessfulSearch.txt
@@ -1,12 +1,6 @@
 // doSuccessfulSearch - store the result of a random succsesful search for use in varius tests
 
  (
-   /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_doSuccessfulSearch.json');
-
   // Extract a known to be active FHIR endpiont
     $randomSampleResourceType := $readDir()[$contains($,/\[.*\]_\[.*\].json/i)][0].$readFile($).resourceType;
   

--- a/maps/isCapstatValidationSuccess.txt
+++ b/maps/isCapstatValidationSuccess.txt
@@ -1,7 +1,7 @@
 /*isCapstatValidationSuccess - This map Gets Validates and Assert CapabilityStatement validation passed succesfuly (done on the correct file & did not raise any errors)*/
 (
   /*Extract the CapStat from the HTTP response and write to a new file*/
-    ;$CapabilityStatement := $readFile('getCapabilityStatement.json').data
+    $CapabilityStatement := $readFile('getCapabilityStatement.json').data
     
     ;$writeFile($CapabilityStatement,'CapabilityStatement.json')
   
@@ -14,18 +14,9 @@
       /*check there are no errors*/
         $not('ERROR' in $ValidationResultsCapabilityStatement.issues.level)
       )
-  
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
+
 
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isCapstatValidationSuccess.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
+
 )

--- a/maps/isCapstatValidationSuccess.txt
+++ b/maps/isCapstatValidationSuccess.txt
@@ -1,11 +1,5 @@
 /*isCapstatValidationSuccess - This map Gets Validates and Assert CapabilityStatement validation passed succesfuly (done on the correct file & did not raise any errors)*/
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isCapstatValidationSuccess.json')
-
   /*Extract the CapStat from the HTTP response and write to a new file*/
     ;$CapabilityStatement := $readFile('getCapabilityStatement.json').data
     

--- a/maps/isDuplicateIds.txt
+++ b/maps/isDuplicateIds.txt
@@ -22,17 +22,6 @@
   // Check for duplicate values (resourceType&id SHALL be unique)
     ;$testResult := $not($arr.*~>$max()>1)
 
-    /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isDuplicateIds.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isDuplicateIds.txt
+++ b/maps/isDuplicateIds.txt
@@ -1,14 +1,9 @@
 // isDuplicateIds (Test28) -  Check the ID is unique for the resource type in the sampled data
 
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isDuplicateIds.json')
-  
+ 
   // run test
-    ;$arr :=
+    $arr :=
     (
       $readDir()[$contains($,/\[.*\]_\[.*\].json/i)] // Extract all sampled file names
       .$readFile($) // Conceptualy the file names provide the resourceType and resource.id but we read the files content just to be on the safe side

--- a/maps/isFailedSearchOK.txt
+++ b/maps/isFailedSearchOK.txt
@@ -8,17 +8,6 @@
       ('OperationOutcome' in $readFile('failedSearchResponse.json').data.resourceType) // Assert response includes OperationOutcome as required
       )
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-
-  ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
-  /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isFailedSearchOK.json')
+    /*Write pass/fail msg based on test results*/
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isGetContentTypeOK
+++ b/maps/isGetContentTypeOK
@@ -6,17 +6,6 @@
       ($readFile('successfulReadResponse.json').headers.'content-type')
     ,'application/fhir+json')
   
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isGetContentTypeOK.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isGetContentTypeOK
+++ b/maps/isGetContentTypeOK
@@ -1,13 +1,8 @@
 // isGetContentTypeOK - This map Assert Content-Type='application/fhir+json' on a simple read (GET) response
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isGetContentTypeOK.json')
 
   /*Perform test*/
-    ;$testResult :=   $contains(
+    $testResult :=   $contains(
       ($readFile('successfulReadResponse.json').headers.'content-type')
     ,'application/fhir+json')
   

--- a/maps/isGetHttp200.txt
+++ b/maps/isGetHttp200.txt
@@ -1,6 +1,5 @@
 (
   /*isGetHttp200 - This mapping ensures a 200 status code is returned for successful read (GET) request, which is implemented in the 'doSuccessfulReadResponse' mapping
-  /*Write initial map status for UI to status file*/
 
   /*Perform test*/
     $testResult := $readFile('successfulReadResponse.json').status = 200

--- a/maps/isGetHttp200.txt
+++ b/maps/isGetHttp200.txt
@@ -5,17 +5,6 @@
   /*Perform test*/
     $testResult := $readFile('successfulReadResponse.json').status = 200
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isGetHttp200.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isGetHttp200.txt
+++ b/maps/isGetHttp200.txt
@@ -1,14 +1,9 @@
 (
   /*isGetHttp200 - This mapping ensures a 200 status code is returned for successful read (GET) request, which is implemented in the 'doSuccessfulReadResponse' mapping
   /*Write initial map status for UI to status file*/
-  
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isGetHttp200.json')
 
   /*Perform test*/
-    ;$testResult := $readFile('successfulReadResponse.json').status = 200
+    $testResult := $readFile('successfulReadResponse.json').status = 200
 
   /*Prep pass & fail msg*/
     ;$msgPassed :={

--- a/maps/isMetaDataHttp200.txt
+++ b/maps/isMetaDataHttp200.txt
@@ -3,17 +3,6 @@
   /*Perform test*/
     $testResult := $readFile('getCapabilityStatement.json').status = 200
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isMetaDataHttp200.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isMetaDataHttp200.txt
+++ b/maps/isMetaDataHttp200.txt
@@ -1,13 +1,7 @@
 /*isMetaDataHttp200 - This map checks if the response for fetching the serveres CapabilityStatement indludes status = 200*/
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isMetaDataHttp200.json')
-
   /*Perform test*/
-    ;$testResult := $readFile('getCapabilityStatement.json').status = 200
+    $testResult := $readFile('getCapabilityStatement.json').status = 200
 
   /*Prep pass & fail msg*/
     ;$msgPassed :={

--- a/maps/isMetadataContentTypeOk.txt
+++ b/maps/isMetadataContentTypeOk.txt
@@ -1,13 +1,7 @@
 /*isMetadataContentTypeOk - This map Assert Content-Type='application/fhir+json'*/
 (
-    /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isMetadataResourceTypeOk.json')
-
   /*Perform test*/
-    ;$testResult :=   $contains(
+    $testResult :=   $contains(
       ($readFile('getCapabilityStatement.json').headers.'content-type')
     ,'application/fhir+json')
   

--- a/maps/isMetadataContentTypeOk.txt
+++ b/maps/isMetadataContentTypeOk.txt
@@ -5,17 +5,6 @@
       ($readFile('getCapabilityStatement.json').headers.'content-type')
     ,'application/fhir+json')
   
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isMetadataContentTypeOk.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isMetadataResourceTypeOk.txt
+++ b/maps/isMetadataResourceTypeOk.txt
@@ -1,13 +1,8 @@
 /*isMetadataResourceTypeOk - This map Asserts resourceType='CapabilityStatement'*/
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isMetadataResourceTypeOk.json')
 
   /*Perform test*/
-    ;$testResult := $readFile('getCapabilityStatement.json').data.resourceType='CapabilityStatement'
+    $testResult := $readFile('getCapabilityStatement.json').data.resourceType='CapabilityStatement'
   
   /*Prep pass & fail msg*/
     ;$msgPassed :={

--- a/maps/isMetadataResourceTypeOk.txt
+++ b/maps/isMetadataResourceTypeOk.txt
@@ -4,17 +4,6 @@
   /*Perform test*/
     $testResult := $readFile('getCapabilityStatement.json').data.resourceType='CapabilityStatement'
   
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isMetadataResourceTypeOk.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isPagingSearch.txt
+++ b/maps/isPagingSearch.txt
@@ -1,14 +1,8 @@
 // isPagingSearch (test 118) - Test FHIR endpoint pages results as reuired (_count support is mandatory, a search on any resourceType with 2 instances or more using _count=1 will force the server to page results)
 
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isPagingSearch.json')
-
   /*Perform test*/
-    ;$testResult := (
+    $testResult := (
       // extract resource counts done by another mapping
         $resourceCount := $readFile('doCountResources.json')[status=200]
 

--- a/maps/isPagingSearch.txt
+++ b/maps/isPagingSearch.txt
@@ -24,17 +24,6 @@
         ;$filter($linkRelationsReturned, function($v){$v in $linkRelationsApproved})~>$count()>1
     )
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isPagingSearch.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isReadHasId.txt
+++ b/maps/isReadHasId.txt
@@ -7,17 +7,6 @@
       $readFile('successfulReadResponse.json').data.id~>$exists()
     )
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isReadHasId.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isReadHasId.txt
+++ b/maps/isReadHasId.txt
@@ -1,14 +1,8 @@
 // isReadHasId (Test29) - The returned resource SHALL have an id element
 
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isReadHasId.json')
-
   /*Perform test*/
-    ;$testResult :=
+    $testResult :=
     (
       $readFile('successfulReadResponse.json').data.id~>$exists()
     )

--- a/maps/isReadId.txt
+++ b/maps/isReadId.txt
@@ -8,17 +8,6 @@
       ;$id = $readFile('successfulReadResponsePrms.json').instanceId // check if id on request = id on response
     )
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isReadId.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isReadId.txt
+++ b/maps/isReadId.txt
@@ -1,13 +1,7 @@
 // isReadId (Test 87) - On simple read (GET), check response resource ID matches input ID
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isReadId.json')
-
   /*Perform test*/
-    ;$testResult :=
+    $testResult :=
     (
       $id := $readFile('successfulReadResponse.json').data.id
 

--- a/maps/isReadIdRegex.txt
+++ b/maps/isReadIdRegex.txt
@@ -1,13 +1,7 @@
 // isReadIdRegex (Test 85) - On simple read (GET), check response resource id matches the datatype id regex
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isReadIdRegex.json')
-
   /*Perform test*/
-    ;$testResult :=
+    $testResult :=
     (
       $id := $readFile('successfulReadResponse.json').data.id
 

--- a/maps/isReadIdRegex.txt
+++ b/maps/isReadIdRegex.txt
@@ -8,17 +8,6 @@
       ;$idRegexMatch($id) // check if id matches HL7 id data type defined rexeg
     )
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isReadIdRegex.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isReadResource.txt
+++ b/maps/isReadResource.txt
@@ -1,13 +1,7 @@
 // isReadResource (Test 84) - On simple read (GET), Check simple read returns a resource and not a bundle
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isReadResource.json')
-
   /*Perform test*/
-    ;$testResult :=
+    $testResult :=
     (
         $responseResourceType := $readFile('successfulReadResponse.json').data.resourceType;
 

--- a/maps/isReadResource.txt
+++ b/maps/isReadResource.txt
@@ -12,17 +12,6 @@
         $responseResourceType != 'Bundle'
     )
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isReadResource.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isSearchModiferOk.txt
+++ b/maps/isSearchModiferOk.txt
@@ -1,13 +1,8 @@
 /*isSearchModiferOk - Test28 - Server SHALL reject any search request that contains a modifier that the server does not support for that parameter*/
 (
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isSearchModiferOk.json')
 
   /*Fetch base url*/
-    ;$baseUrl := $search('Patient').link[relation='self'].url~>$substringBefore('Patient?')
+    $baseUrl := $search('Patient').link[relation='self'].url~>$substringBefore('Patient?')
   
   /*Search with an unsupported modifer*/
     ;$testResult := $http({

--- a/maps/isSearchModiferOk.txt
+++ b/maps/isSearchModiferOk.txt
@@ -12,17 +12,6 @@
         'url': 'Patient?birthdate:xyz=eq3000-01-01' /*:xyz is a made up modifier name and hence no server will support it for any SPs*/
         }).status = 400
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isSearchModiferOk.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isSuccessfulSearchBundle.txt
+++ b/maps/isSuccessfulSearchBundle.txt
@@ -4,17 +4,6 @@
   /*Perform test*/
     $testResult := $readFile('SuccessfulSearchResponse.json').data.resourceType = 'Bundle'
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isSuccessfulSearchBundle.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isSuccessfulSearchBundle.txt
+++ b/maps/isSuccessfulSearchBundle.txt
@@ -1,14 +1,8 @@
 /*isSuccessfulSearchBundle (Test108) - This map validates that search reslut is Bundle*/
 
 (
-  /*Write initial map status for UI to status file*/ 
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isSuccessfulSearchBundle.json')
-
   /*Perform test*/
-    ;$testResult := $readFile('SuccessfulSearchResponse.json').data.resourceType = 'Bundle'
+    $testResult := $readFile('SuccessfulSearchResponse.json').data.resourceType = 'Bundle'
 
   /*Prep pass & fail msg*/
     ;$msgPassed :={

--- a/maps/isSuccessfulSearchBundleType.txt
+++ b/maps/isSuccessfulSearchBundleType.txt
@@ -3,17 +3,6 @@
   /*Perform test*/
     $testResult := $readFile('SuccessfulSearchResponse.json').data.type = 'searchset'
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-  
-    ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isSuccessfulSearchBundleType.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/isSuccessfulSearchBundleType.txt
+++ b/maps/isSuccessfulSearchBundleType.txt
@@ -1,14 +1,7 @@
 /*isSuccessfulSearchBundleType (Test109) - This map validates that search result is Bundle of type 'searchset' */
 (
-   
- /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isSuccessfulSearchBundleType.json')
-
   /*Perform test*/
-    ;$testResult := $readFile('SuccessfulSearchResponse.json').data.type = 'searchset'
+    $testResult := $readFile('SuccessfulSearchResponse.json').data.type = 'searchset'
 
   /*Prep pass & fail msg*/
     ;$msgPassed :={

--- a/maps/isSuccessfulSearchCode.txt
+++ b/maps/isSuccessfulSearchCode.txt
@@ -1,14 +1,8 @@
 // isSuccessfulSearchCode (test 115) - Assert server returned an HTTP 200 response code to a Successful search request => If the search succeeds, the server SHALL return a 200 OK HTTP status code 3.1.0.9 search https://www.hl7.org/fhir/r4/http.html#search
 
 ( 
-  /*Write initial map status for UI to status file*/
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_isSuccessfulSearchCode.json')
-  
   /*Perform test*/
-    ;$testResult := ($readFile('SuccessfulSearchResponse.json').status = 200) // Assert HTTP response code is 200 as required
+    $testResult := ($readFile('SuccessfulSearchResponse.json').status = 200) // Assert HTTP response code is 200 as required
 
   /*Prep pass & fail msg*/
     ;$msgPassed :={

--- a/maps/isSuccessfulSearchCode.txt
+++ b/maps/isSuccessfulSearchCode.txt
@@ -4,17 +4,6 @@
   /*Perform test*/
     $testResult := ($readFile('SuccessfulSearchResponse.json').status = 200) // Assert HTTP response code is 200 as required
 
-  /*Prep pass & fail msg*/
-    ;$msgPassed :={
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    }
-
-  ;$msgFailed := {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    }
-
   /*Write pass/fail msg based on test results*/
-    ;$writeFile(($testResult ? $msgPassed : $msgFailed),'actionStatus_isSuccessfulSearchCode.json')
+    ;$testResult ? $setStatus('passed', 'Passed') : $setStatus('failed', 'Failed')
 )

--- a/maps/mockAction10e.txt
+++ b/maps/mockAction10e.txt
@@ -1,8 +1,4 @@
 (
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_mockAction10e.json');
     $wait(10000);
     $error('This is also an intentional error but with a longer text so we cacn see how it looks in the table of the report web page. Some more text is added here just to make it extra long');
 )

--- a/maps/mockAction10f.txt
+++ b/maps/mockAction10f.txt
@@ -1,8 +1,4 @@
 (
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_mockAction10f.json');
     $wait(10000);
     {
       'statusCode':'failed'

--- a/maps/mockAction10f.txt
+++ b/maps/mockAction10f.txt
@@ -1,7 +1,4 @@
 (
     $wait(10000);
-    {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    } ~> $writeFile('actionStatus_mockAction10f.json');
+    $setStatus('failed', 'Failed');
 )

--- a/maps/mockAction10s.txt
+++ b/maps/mockAction10s.txt
@@ -1,7 +1,4 @@
 (
     $wait(10000);
-    {
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    } ~> $writeFile('actionStatus_mockAction10s.json');
+    $setStatus('passed', 'Passed');
 )

--- a/maps/mockAction10s.txt
+++ b/maps/mockAction10s.txt
@@ -1,8 +1,4 @@
 (
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_mockAction10s.json');
     $wait(10000);
     {
       'statusCode':'passed'

--- a/maps/mockAction1e.txt
+++ b/maps/mockAction1e.txt
@@ -1,8 +1,4 @@
 (
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_mockAction1e.json');
     $wait(1000);
     $error('Intentional error');
 )

--- a/maps/mockAction1f.txt
+++ b/maps/mockAction1f.txt
@@ -1,7 +1,4 @@
 (
     $wait(1000);
-    {
-      'statusCode':'failed'
-      ,'statusText':'Failed'
-    } ~> $writeFile('actionStatus_mockAction1f.json');
+    $setStatus('failed', 'Failed');
 )

--- a/maps/mockAction1f.txt
+++ b/maps/mockAction1f.txt
@@ -1,8 +1,4 @@
 (
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_mockAction1f.json');
     $wait(1000);
     {
       'statusCode':'failed'

--- a/maps/mockAction1s.txt
+++ b/maps/mockAction1s.txt
@@ -1,8 +1,4 @@
 (
-    {
-      'statusCode':'in-progress'
-      ,'statusText':'in-progress'
-    } ~> $writeFile('actionStatus_mockAction1s.json');
     $wait(1000);
     {
       'statusCode':'passed'

--- a/maps/mockAction1s.txt
+++ b/maps/mockAction1s.txt
@@ -1,7 +1,4 @@
 (
     $wait(1000);
-    {
-      'statusCode':'passed'
-      ,'statusText':'Passed'
-    } ~> $writeFile('actionStatus_mockAction1s.json');
+    $setStatus('passed', 'Passed');
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "il-fhir-certificator",
-  "version": "1.16.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "il-fhir-certificator",
-      "version": "1.16.0",
+      "version": "1.18.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@inquirer/prompts": "^5.5.0",
@@ -16,7 +16,7 @@
         "dotenv": "^16.4.7",
         "fhir-validator-js": "^1.3.0",
         "fs-extra": "^11.2.0",
-        "fume-fhir-converter": "^2.16.2",
+        "fume-fhir-converter": "^2.18.5",
         "json2md": "^2.0.1",
         "jsonata": "^2.0.6",
         "path": "^0.12.7",
@@ -4498,22 +4498,18 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
-      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4994,9 +4990,9 @@
       }
     },
     "node_modules/fume-fhir-converter": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/fume-fhir-converter/-/fume-fhir-converter-2.16.2.tgz",
-      "integrity": "sha512-pVq8q/rv0kMagU14amFfu0zcUk0u4GPHpw4x/yQAaKBKGYh2mpw3ITjxW6XCPnMWj3Wfq+KzucJIlx+I6SyIuw==",
+      "version": "2.18.5",
+      "resolved": "https://registry.npmjs.org/fume-fhir-converter/-/fume-fhir-converter-2.18.5.tgz",
+      "integrity": "sha512-q8wLxJsd2BMJPBosKYfkOAJbEruF3wfSc3ju5oRYY7r3VoEwvrCNNwhS5hUacylwVHNGhc9BJ2MnxJveiaBmVQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "axios": "^1.7.9",
@@ -5004,7 +5000,7 @@
         "csvtojson": "^2.0.10",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
-        "fast-xml-parser": "^4.5.0",
+        "fast-xml-parser": "^4.5.1",
         "fs-extra": "^11.2.0",
         "hl7-dictionary": "^1.0.1",
         "hl7js": "^0.0.6",
@@ -5013,7 +5009,7 @@
         "tar": "^7.4.3",
         "temp": "^0.9.4",
         "uuid-by-string": "^4.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.24.1"
       }
     },
     "node_modules/fume-fhir-converter/node_modules/brace-expansion": {
@@ -7699,9 +7695,15 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -8458,9 +8460,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "il-fhir-certificator",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "FHIR Certificator for Israeli MoH",
   "scripts": {
     "clean": "rimraf dist && rimraf ui\\dist && rimraf report\\dist",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dotenv": "^16.4.7",
     "fhir-validator-js": "^1.3.0",
     "fs-extra": "^11.2.0",
-    "fume-fhir-converter": "^2.16.2",
+    "fume-fhir-converter": "^2.18.5",
     "json2md": "^2.0.1",
     "jsonata": "^2.0.6",
     "path": "^0.12.7",

--- a/src/helpers/loadMaps.ts
+++ b/src/helpers/loadMaps.ts
@@ -8,8 +8,8 @@ import chalk from 'chalk';
 const folderPath: string = path.join(path.resolve('.'), 'maps');
 
 const toFunction = (mapping: string) => {
-  return async (input: any | any[]) => {
-    const res: any | any[] = await getFumeServer().transform(input, mapping);
+  return async (input: any | any[], bindings: Record<string, any | any[]> = {}) => {
+    const res = await getFumeServer().transform(input, mapping, bindings);
     return res;
   };
 };


### PR DESCRIPTION
* all actions have default lifecycle statuses written automatically (init -> in-progress -> completed)
* removed all explicit status file writing except custom statuses (passed/failed)
* using new function $setStatus() for cutom status reporting, without needing to hard-code the action/mapping name