### PR TITLE
fix (sampling map endless loop)

### DIFF
--- a/maps/doSampleResources.txt
+++ b/maps/doSampleResources.txt
@@ -212,18 +212,43 @@
     /* iteration function that adds resources recursively, as long as: */
     /* 1. the previous step succeeded in finding a new resource */
     /* 2. the requested amount hasn't been collected yet */
-    $iterator := function($currentList, $previousList){(
+    $iterator := function($currentList, $previousList, $emptyListCounter)
+	{(
       $warning('$iterator called with following params');
       $warning({'$currentList count = ' : $count($currentList), '$previousList count = ': $count($previousList)});
-      $count($currentList)>0 and ($count($currentList) = $count($previousList) or $count($currentList) >= $amountToCollect) ? (
+      
+	  $count($currentList) > 0 and 
+	  ($count($currentList) = $count($previousList) or $count($currentList) >= $amountToCollect) ? 
+	  (
         /* the stop condition is met - return list and stop iterating */
         $currentList
-      ) : (
+      ) : 
+	  (
         /* try to add one resource and continue */
         $updatedList := $addResource($resourceType, $searchParam, $elementName, $minDate, $maxDate, $currentList);
         $warning({'$updatedList count': $count($updatedList)});
-        /* tail call */
-        $iterator($updatedList, $currentList)
+        
+		$updatedEmptyListCounter := $count($updatedList) = 0 and $count($currentList) = 0 ? 
+		  (
+		    $exists($emptyListCounter) ? 
+		      $emptyListCounter + 1 
+		      : 
+		      1
+		  ) 
+		  : 
+		  0;
+        $warning({'$updatedEmptyListCounter': $updatedEmptyListCounter});
+
+        $updatedEmptyListCounter > 2 ? 
+	      ( // Adjust the threshold as needed
+            $warning('Iterator stopping because the list has remained empty for too many consecutive iterations.');
+            $currentList
+          ) 
+		  : 
+		  (
+		  /* tail call */
+          $iterator($updatedList, $currentList, $updatedEmptyListCounter)
+		  )
       )
     )};
     /* call the iterator with empty initial lists */


### PR DESCRIPTION
https://app.clickup.com/t/8698fdpun

### Explanation of the Changes I added to doSampleResources.txt :

- $emptyListCounter Parameter: The $iterator function now takes an additional parameter $emptyListCounter to keep track of how many consecutive iterations have resulted in an empty $updatedList when the $currentList was also empty at the start.

- Incrementing the Counter:

Inside the $iterator, after $addResource is called, we check if both $updatedList and $currentList are empty.

If they are, it means no resources have been collected from the beginning. In this case, we increment the $emptyListCounter.

- New Stop Condition:

We introduce a condition: $updatedEmptyListCounter> 2 (you can adjust the threshold). If the $updatedEmptyListCounter exceeds this threshold, it implies that the $addResource function has been unable to collect any resources for a certain number of consecutive attempts right from the start. This is a strong indicator that the sampling criteria (likely the missing elementName) cannot be met, and the loop should be stopped to prevent an infinite run.

- Initial Call: In the $collectResources function, we initialize the $emptyListCounter to 0 when calling the $iterator for the first time.



### How this addresses the issue:

If the CarePlan.period (or any other $elementName) is consistently missing from all resources, the $addResource function will likely return an empty list in each iteration. The $emptyListCounter in the $iterator will then increment. Once this counter exceeds the defined threshold (e.g., 5), the $iterator will recognize that no resources are being collected and will terminate, preventing the endless loop.